### PR TITLE
v0.2.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# Version 0.2.2
+
+- Update `portable-atomic-util` to v0.2.0. (#12)
+
 # Version 0.2.1
 
 - Update `fastrand` to v2.0.0. (#2)

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,7 +5,7 @@ edition = "2018"
 license = "MIT OR Apache-2.0"
 name = "piper"
 repository = "https://github.com/notgull/piper"
-version = "0.2.1"
+version = "0.2.2"
 rust-version = "1.37"
 
 [features]


### PR DESCRIPTION
- Update `portable-atomic-util` to v0.2.0. (#12)
