### PR TITLE
Revert "msrv: Bump to v1.37.0"

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -49,7 +49,7 @@ jobs:
       matrix:
         # When updating this, the reminder to update the minimum supported
         # Rust version in Cargo.toml.
-        rust: ['1.37']
+        rust: ['1.36']
     steps:
       - uses: actions/checkout@v4
       - name: Install Rust

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,5 +1,8 @@
 name: CI
 
+permissions:
+  contents: read
+
 on:
   pull_request:
   push:
@@ -45,17 +48,11 @@ jobs:
 
   msrv:
     runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        # When updating this, the reminder to update the minimum supported
-        # Rust version in Cargo.toml.
-        rust: ['1.36']
     steps:
       - uses: actions/checkout@v4
-      - name: Install Rust
-        run: rustup update ${{ matrix.rust }} && rustup default ${{ matrix.rust }}
-      - run: cargo build --all
-      - run: cargo build --all --no-default-features
+      - name: Install cargo-hack
+        uses: taiki-e/install-action@cargo-hack
+      - run: cargo hack build --feature-powerset --rust-version
 
   clippy:
     runs-on: ubuntu-latest

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,7 @@ license = "MIT OR Apache-2.0"
 name = "piper"
 repository = "https://github.com/notgull/piper"
 version = "0.2.2"
-rust-version = "1.37"
+rust-version = "1.36"
 
 [features]
 default = ["std"]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -215,6 +215,7 @@ macro_rules! ready {
 /// # Panics
 ///
 /// This function panics if `cap` is 0 or if `cap * 2` overflows a `usize`.
+#[allow(clippy::incompatible_msrv)] // false positive: https://github.com/rust-lang/rust-clippy/issues/12280
 pub fn pipe(cap: usize) -> (Reader, Writer) {
     assert!(cap > 0, "capacity must be positive");
     assert!(cap.checked_mul(2).is_some(), "capacity is too large");


### PR DESCRIPTION
See https://github.com/smol-rs/piper/pull/14#issuecomment-2106425343.

This also improves CI setup for msrv check. (see the commit message of the last commit)