### PR TITLE
v0.2.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+# Version 0.2.3
+
+- Relax MSRV to v1.36. (#15)
+- Fix the repository URL in Cargo.toml. (#16)
+
 # Version 0.2.2
 
 - Update `portable-atomic-util` to v0.2.0. (#12)

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,7 +5,7 @@ edition = "2018"
 license = "MIT OR Apache-2.0"
 name = "piper"
 repository = "https://github.com/smol-rs/piper"
-version = "0.2.2"
+version = "0.2.3"
 rust-version = "1.36"
 
 [features]


### PR DESCRIPTION
- Relax MSRV to v1.36. (#15)
- Fix the repository URL in Cargo.toml. (#16)
