### PR TITLE
Fix nondeterministic test suite failures in length measurement functions

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -387,13 +387,9 @@ impl Reader {
     /// # Examples
     ///
     /// ```
-    /// # futures_lite::future::block_on(async {
-    /// # futures_lite::future::poll_fn(|cx| {
     /// let (mut reader, mut writer) = piper::pipe(10);
-    /// let _ = writer.poll_fill_bytes(cx, &[0u8; 5]);
+    /// let _ = writer.try_fill(&[0u8; 5]);
     /// assert_eq!(reader.len(), 5);
-    /// # std::task::Poll::Ready(()) }).await;
-    /// # });
     /// ```
     pub fn len(&self) -> usize {
         self.inner.len()
@@ -406,14 +402,10 @@ impl Reader {
     /// # Examples
     ///
     /// ```
-    /// # futures_lite::future::block_on(async {
-    /// # futures_lite::future::poll_fn(|cx| {
     /// let (mut reader, mut writer) = piper::pipe(10);
     /// assert!(reader.is_empty());
-    /// let _ = writer.poll_fill_bytes(cx, &[0u8; 5]);
+    /// let _ = writer.try_fill(&[0u8; 5]);
     /// assert!(!reader.is_empty());
-    /// # std::task::Poll::Ready(()) }).await;
-    /// # });
     /// ```
     pub fn is_empty(&self) -> bool {
         self.inner.len() == 0
@@ -445,16 +437,12 @@ impl Reader {
     /// # Examples
     ///
     /// ```
-    /// # futures_lite::future::block_on(async {
-    /// # futures_lite::future::poll_fn(|cx| {
     /// let (mut reader, mut writer) = piper::pipe(10);
     /// assert!(!reader.is_full());
-    /// let _ = writer.poll_fill_bytes(cx, &[0u8; 10]);
+    /// let _ = writer.try_fill(&[0u8; 10]);
     /// assert!(reader.is_full());
-    /// let _ = reader.poll_drain_bytes(cx, &mut [0u8; 5]);
+    /// let _ = reader.try_drain(&mut [0u8; 5]);
     /// assert!(!reader.is_full());
-    /// # std::task::Poll::Ready(()) }).await;
-    /// # });
     /// ```
     pub fn is_full(&self) -> bool {
         self.inner.len() == self.inner.cap
@@ -704,13 +692,9 @@ impl Writer {
     /// # Examples
     ///
     /// ```
-    /// # futures_lite::future::block_on(async {
-    /// # futures_lite::future::poll_fn(|cx| {
     /// let (_reader, mut writer) = piper::pipe(10);
-    /// let _ = writer.poll_fill_bytes(cx, &[0u8; 5]);
+    /// let _ = writer.try_fill(&[0u8; 5]);
     /// assert_eq!(writer.len(), 5);
-    /// # std::task::Poll::Ready(()) }).await;
-    /// # });
     /// ```
     pub fn len(&self) -> usize {
         self.inner.len()
@@ -723,14 +707,10 @@ impl Writer {
     /// # Examples
     ///
     /// ```
-    /// # futures_lite::future::block_on(async {
-    /// # futures_lite::future::poll_fn(|cx| {
     /// let (_reader, mut writer) = piper::pipe(10);
     /// assert!(writer.is_empty());
-    /// let _ = writer.poll_fill_bytes(cx, &[0u8; 5]);
+    /// let _ = writer.try_fill(&[0u8; 5]);
     /// assert!(!writer.is_empty());
-    /// # std::task::Poll::Ready(()) }).await;
-    /// # });
     /// ```
     pub fn is_empty(&self) -> bool {
         self.inner.len() == 0
@@ -762,16 +742,12 @@ impl Writer {
     /// # Examples
     ///
     /// ```
-    /// # futures_lite::future::block_on(async {
-    /// # futures_lite::future::poll_fn(|cx| {
     /// let (mut reader, mut writer) = piper::pipe(10);
     /// assert!(!writer.is_full());
-    /// let _ = writer.poll_fill_bytes(cx, &[0u8; 10]);
+    /// let _ = writer.try_fill(&[0u8; 10]);
     /// assert!(writer.is_full());
-    /// let _ = reader.poll_drain_bytes(cx, &mut [0u8; 5]);
+    /// let _ = reader.try_drain(&mut [0u8; 5]);
     /// assert!(!writer.is_full());
-    /// # std::task::Poll::Ready(()) }).await;
-    /// # });
     /// ```
     pub fn is_full(&self) -> bool {
         self.inner.len() == self.inner.cap


### PR DESCRIPTION
The test suite for the following functions exhibited nondeterministic
behavior:

- {Reader, Writer}::len()
- {Reader, Writer}::is_full()
- {Reader, Writer}::len()

This is because they used the functions "poll_fill_bytes" and
"poll_drain_bytes", which introduce a random chance to yield in order to
improve contention under certain conditions. However this yield has a
chance of kicking in and making these functions read/write 0 bytes
instead of the desired number of bytes, causing tests to fail.

To fix this issue I have replaced the functions used in these tests with
"try_fill" and "try_drain". These do not yield and therefore allow these
tests to be deterministic.

Closes #18
